### PR TITLE
feat: show xud-docker setup details

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -226,6 +227,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -14,4 +14,5 @@ docker run -it --rm --name proxy \
 -v "$HOME/.xud-docker/$NETWORK/data/lndbtc:/root/.lndbtc" \
 -v "$HOME/.xud-docker/$NETWORK/data/lndltc:/root/.lndltc" \
 -v "$HOME/.xud-docker/$NETWORK/logs/config.sh:/root/config.sh" \
+-v "$HOME/.xud-docker/$NETWORK:/root/network:ro" \
 proxy


### PR DESCRIPTION
This PR adds a new endpoint `/api/v1/setup-status`. It shows the details of xud-docker setup process.

```
➜  ~ curl localhost:8080/api/v1/setup-status
{"status":"Waiting for XUD dependencies to be ready","details":null}
{"status":"Syncing light clients","details":{"lndbtc":"Syncing 0.00% (0/0)","lndltc":"Syncing 0.00% (0/0)"}}
{"status":"Syncing light clients","details":{"lndbtc":"Syncing 0.00% (0/1890767)","lndltc":"Syncing 0.00% (0/0)"}}
{"status":"Syncing light clients","details":{"lndbtc":"Syncing 0.00% (0/1890767)","lndltc":"Syncing 0.00% (0/1677117)"}}
{"status":"Syncing light clients","details":{"lndbtc":"Syncing 0.00% (0/1890767)","lndltc":"Syncing 0.00% (0/1677117)"}}
...
{"status":"Setup wallets","details":null}
{"status":"Create wallets","details":null}
{"status":"Setup backup location","details":null}
{"status":"Unlock wallets","details":null}
```

The stream HTTP response could be changed to SSE (HTTP Server-Sent Events) if it is more convenient to use in frontend. @krrprr @erkarl 