### PR TITLE
feat: add endpoints for trading

### DIFF
--- a/service/xud/rpc.go
+++ b/service/xud/rpc.go
@@ -219,3 +219,55 @@ func (t *RpcClient) GetMnemonic(ctx context.Context) (*pb.GetMnemonicResponse, e
 	req := pb.GetMnemonicRequest{}
 	return client.GetMnemonic(ctx, &req)
 }
+
+func (t *RpcClient) ListPairs(ctx context.Context) (*pb.ListPairsResponse, error) {
+	client, err := t.getClient()
+	if err != nil {
+		return nil, err
+	}
+	req := pb.ListPairsRequest{}
+	return client.ListPairs(ctx, &req)
+}
+
+func (t *RpcClient) ListOrders(ctx context.Context, pairId string, owner pb.ListOrdersRequest_Owner, limit uint32, includeAliases bool) (*pb.ListOrdersResponse, error) {
+	client, err := t.getClient()
+	if err != nil {
+		return nil, err
+	}
+	req := pb.ListOrdersRequest{
+		PairId:         pairId,
+		Owner:          owner,
+		Limit:          limit,
+		IncludeAliases: includeAliases,
+	}
+	return client.ListOrders(ctx, &req)
+}
+
+func (t *RpcClient) PlaceOrder(ctx context.Context, pairId string, side pb.OrderSide, price float64, quantity uint64, orderId string, replaceOrderId string, immediateOrCancel bool) (*pb.PlaceOrderResponse, error) {
+	client, err := t.getClient()
+	if err != nil {
+		return nil, err
+	}
+	req := pb.PlaceOrderRequest{
+		PairId:            pairId,
+		Side:              side,
+		Price:             price,
+		Quantity:          quantity,
+		OrderId:           orderId,
+		ReplaceOrderId:    replaceOrderId,
+		ImmediateOrCancel: immediateOrCancel,
+	}
+	return client.PlaceOrderSync(ctx, &req)
+}
+
+func (t *RpcClient) RemoveOrder(ctx context.Context, orderId string, quantity uint64) (*pb.RemoveOrderResponse, error) {
+	client, err := t.getClient()
+	if err != nil {
+		return nil, err
+	}
+	req := pb.RemoveOrderRequest{
+		OrderId:  orderId,
+		Quantity: quantity,
+	}
+	return client.RemoveOrder(ctx, &req)
+}


### PR DESCRIPTION
This PR adds API endpoints for existing xud rpc calls needed by https://github.com/ExchangeUnion/xud-ui/issues/32
- listpairs
`curl -k {api_url}/api/v1/xud/listpairs`
- listorders
`curl -k {api_url}/api/v1/xud/listorders`
with params:
`curl -k {api_url}/api/v1/xud/listorders?pairId=LTC/BTC&owner=1&limit=2&includeAliases=true`
- placeorder
`curl -k -d '{"pairId": "ETH/BTC", "quantity": 100, "side": 0}' -H 'Content-Type: application/json' {api_url}/api/v1/xud/placeorder`
- removeorder
`curl -k -d '{"orderId": "bb695670-4474-11eb-ba95-f9b5fb01b4ea"}' -H 'Content-Type: application/json' {api_url}/api/v1/xud/removeorder`

For all calls, any request parameters that exist in xudrpc should be accessible here as well with the difference that the parameter names are in camel case.

`orderbook` endpoint will be implemented separately once it's available in the xudrpc.